### PR TITLE
Added initial UDP server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+src/udp_server

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 build/
-src/udp_server

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,17 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(lunar-net-protocol VERSION 0.1.0 LANGUAGES C CXX)
 
-add_executable(lunar-net-protocol main.cpp)
+# Find dependencies
 find_package(Boost REQUIRED COMPONENTS system)
-find_package(nlohmann_json REQUIRED)
 
-# Define the source files for the UDP server
+# Define the source files for the UDP server and main logic
 set(SOURCES
+    main.cpp
     src/udp_server.cpp
 )
 
-# Create the UDP server executable
-add_executable(udp_server ${SOURCES})
+# Create a single executable
+add_executable(lunar-net-protocol ${SOURCES})
 
-# Link Boost and JSON libraries (after defining udp_server)
-target_link_libraries(udp_server PRIVATE Boost::system nlohmann_json::nlohmann_json)
+# Link Boost (and other necessary dependencies)
+target_link_libraries(lunar-net-protocol PRIVATE Boost::system)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,16 @@ cmake_minimum_required(VERSION 3.5.0)
 project(lunar-net-protocol VERSION 0.1.0 LANGUAGES C CXX)
 
 add_executable(lunar-net-protocol main.cpp)
+find_package(Boost REQUIRED COMPONENTS system)
+find_package(nlohmann_json REQUIRED)
 
+# Define the source files for the UDP server
+set(SOURCES
+    src/udp_server.cpp
+)
+
+# Create the UDP server executable
+add_executable(udp_server ${SOURCES})
+
+# Link Boost and JSON libraries (after defining udp_server)
+target_link_libraries(udp_server PRIVATE Boost::system nlohmann_json::nlohmann_json)

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,20 @@
-#include <iostream>
+#include "src/udp_server.hpp"
+#include <boost/asio.hpp>
 
-int main(int, char**){
-    std::cout << "Hello, from lunar-net-protocol!\n";
+int main() {
+    try {
+        boost::asio::io_context io_context;
+        UdpServer server(io_context, 5000);
+
+        server.set_receive_callback([&server](const std::string& message) {
+            std::cout << "[CALLBACK] Received message: " << message << std::endl;
+        });
+
+        server.start();
+        io_context.run();
+    } catch (std::exception &e) {
+        std::cerr << "[ERROR] " << e.what() << std::endl;
+    }
+
+    return 0;
 }

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <boost/asio.hpp>
+#include <unordered_set>
+#include <nlohmann/json.hpp> // JSON handling
+
+using json = nlohmann::json;
+using boost::asio::ip::udp;
+
+const int SERVER_PORT = 5000; // UDP server listens on this port
+std::unordered_set<int> received_packets; // Store sequence numbers to track missing ones
+
+void process_message(const std::string& message,udp::socket& socket,udp::endpoint sender_endpoint) {
+    try {
+        json received_json = json::parse(message);
+        int seq_num = received_json["seq_num"]; // Extract sequence number
+        std::string data = received_json["data"]; // Extract message content
+        // Check for duplicate packets
+        if (received_packets.count(seq_num)) {
+            std::cout << "[DUPLICATE] Ignored packet: " << seq_num << std::endl;
+            return;
+        }
+        // Store received packet number
+        received_packets.insert(seq_num);
+        std::cout << "[RECEIVED] Packet " << seq_num << ": " << data << std::endl;
+
+    } catch (std::exception& e) {
+        std::cerr << "[ERROR] Invalid message format: " << e.what() << std::endl;
+    }
+}
+
+int main() {
+    try {
+        boost::asio::io_context io_context;
+        udp::socket socket(io_context, udp::endpoint(udp::v4(), SERVER_PORT));
+
+        char buffer[1024];
+        udp::endpoint sender_endpoint;
+
+        std::cout << "[SERVER] UDP Server is running on port "<< SERVER_PORT << "..." << std::endl;
+
+        while (true) {
+            size_t length = socket.receive_from(boost::asio::buffer(buffer), sender_endpoint);
+            std::string received_message(buffer, length);
+
+            process_message(received_message, socket, sender_endpoint);
+        }
+
+    } catch (std::exception &e) {
+        std::cerr << "[ERROR] " << e.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/src/udp_server.hpp
+++ b/src/udp_server.hpp
@@ -1,0 +1,26 @@
+#ifndef UDP_SERVER_HPP
+#define UDP_SERVER_HPP
+
+#include <iostream>
+#include <boost/asio.hpp>
+#include <functional>
+
+using boost::asio::ip::udp;
+
+class UdpServer {
+public:
+    UdpServer(boost::asio::io_context& context, int port);
+    void start();
+    void set_receive_callback(std::function<void(const std::string&)> callback);
+    void send_data(const std::string& message, const udp::endpoint& recipient);
+
+private:
+    void receive_data();
+
+    udp::socket socket_;
+    udp::endpoint sender_endpoint_;
+    char buffer_[1024];
+    std::function<void(const std::string&)> receive_callback_;
+};
+
+#endif  // UDP_SERVER_HPP


### PR DESCRIPTION
This PR adds the initial implementation of the UDP server. 

✅ **Features:**
- Receives UDP messages
- Tracks sequence numbers to detect duplicates
- Uses Boost.Asio for networking

📌 **Setup Instructions** (Important):  
Before building, **make sure Boost is installed** on Linux:
sudo apt install libboost-all-dev

📌 How to Build and Run the Server:
Navigate to the repo folder in Linux (WSL/Ubuntu):

cd ~/lunar-net-protocol

Create a build directory and move into it:

mkdir -p build && cd build

 Generate build files and compile the project:

cmake ..
make

Run the UDP server:

./udp_server

📌 How to Send a Test Message (Using netcat):
Open a new terminal and send a message to the server:

echo '{"seq_num":1,"data":"Hello Server"}' | nc -u 127.0.0.1 5000

✅ Expected Output on Server:
[RECEIVED] Packet 1: Hello Server

📌 Testing Duplicate Handling:
Send the same message again to test duplicate detection (Ctrl+C to stop the previous sent message):

echo '{"seq_num":1,"data":"Hello Server"}' | nc -u 127.0.0.1 5000

✅ Expected Output on Server:

[DUPLICATE] Ignored packet: 1